### PR TITLE
Ignore whitespace after parameter delimiter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterParser.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterParser.java
@@ -34,7 +34,7 @@ public class ParameterParser {
 			//the default splitter message in this scenario is not user friendly, so snip a trailing semicolon
 			clean = clean.substring(0, clean.length() - 1);
 		}
-		return Splitter.on(PAIR_SEPARATOR).withKeyValueSeparator(NAME_VALUE_SEPARATOR).split(clean);
+		return Splitter.on(PAIR_SEPARATOR).trimResults().withKeyValueSeparator(NAME_VALUE_SEPARATOR).split(clean);
 	}
 
 	public String checkSanity(String cronTabSpec, ParametersDefinitionProperty parametersDefinitionProperty) {

--- a/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterParserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterParserTest.java
@@ -82,6 +82,16 @@ public class ParameterParserTest {
 	}
 
 	@Test
+	public void test_TwoParamsStringWithSpaceReturns_emptyMap() {
+		ParameterParser testObject = new ParameterParser();
+
+		HashMap<String, String> expected = new HashMap<String, String>();
+		expected.put("name", "value");
+		expected.put("name2", "value2");
+		assertEquals(expected, testObject.parse("name2=value2; name=value"));
+	}
+
+	@Test
 	public void checkSanity_HappyPath() throws Exception {
 		ParameterParser testObject = new ParameterParser();
 


### PR DESCRIPTION
When a user entered a line with whitespace after the parameter
delimiter(;), that whitespace was included in the key for that key/value
pair. For example, if `* * * * * % key1=value1; key2=value2` was
entered, the second key to be `" key2"` rather than `"key2"`. Invoking
`trimResults()` on the splitter resolves the issue.