### PR TITLE
Support Pipeline with bugfix (based on peopplen's PR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+parameterized-scheduler.iml
 .classpath
 .settings
 .project

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>2.2</version>
+		<version>1.642.3</version>
 	</parent>
 
 	<artifactId>parameterized-scheduler</artifactId>
@@ -14,7 +14,6 @@
 
 	<properties>
 		<jenkins.version>1.642.3</jenkins.version>
-		<maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
 	</properties>
 
 	<name>Parameterized Scheduler</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,17 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.565.3</version>
+		<version>2.2</version>
 	</parent>
 
 	<artifactId>parameterized-scheduler</artifactId>
 	<version>0.3-SNAPSHOT</version>
 	<packaging>hpi</packaging>
+
+	<properties>
+		<jenkins.version>1.642.3</jenkins.version>
+		<maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
+	</properties>
 
 	<name>Parameterized Scheduler</name>
 	<description>Lets you define many cron-like format but with additional parameters for each definition</description>
@@ -58,6 +63,12 @@
 			<artifactId>mockito-all</artifactId>
 			<version>1.9.5</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-job</artifactId>
+			<version>2.1</version>
+			<optional>true</optional>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/Cron.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/Cron.java
@@ -6,12 +6,14 @@ import hudson.model.AbstractProject;
 import hudson.triggers.Trigger;
 
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
 @Extension
 public class Cron extends PeriodicWork {
@@ -27,26 +29,39 @@ public class Cron extends PeriodicWork {
 	@Override
 	protected void doRun() throws Exception {
 		LOGGER.finer("dorun-run");
-		checkTriggers(new GregorianCalendar());
-	}
 
-	private void checkTriggers(Calendar calendar) {
 		Jenkins instance = Jenkins.getInstance();
 
-		for (AbstractProject<?, ?> project : instance.getAllItems(AbstractProject.class)) {
-			for (Trigger<?> trigger : project.getTriggers().values()) {
-				if (trigger instanceof ParameterizedTimerTrigger) {
-					LOGGER.fine("cron checking " + project.getName());
-					ParameterizedTimerTrigger ptTrigger = (ParameterizedTimerTrigger) trigger;
+		if (instance == null) {
+			LOGGER.severe("Jenkins not initialized");
+			return;
+		}
 
-					try {
-						ptTrigger.checkCronTabsAndRun(calendar);
-					} catch (Throwable e) {
-						// t.run() is a plugin, and some of them throw RuntimeException and other things.
-						// don't let that cancel the polling activity. report and move on.
-						LOGGER.log(Level.WARNING,
-								trigger.getClass().getName() + ".run() failed for " + project.getName(), e);
-					}
+		for (AbstractProject<?, ?> project : instance.getAllItems(AbstractProject.class)) {
+			checkTriggers(project.getName(), project.getTriggers().values(), new GregorianCalendar());
+		}
+
+		if (instance.getPlugin("workflow-job") != null) {
+			for (WorkflowJob workflowJob : instance.getAllItems(WorkflowJob.class)) {
+				checkTriggers(workflowJob.getName(), workflowJob.getTriggers().values(), new GregorianCalendar());
+			}
+		}
+	}
+
+	private void checkTriggers(String projectName, Collection<Trigger<?>> triggers, Calendar calendar) {
+
+		for (Trigger<?> trigger : triggers) {
+			if (trigger instanceof ParameterizedTimerTrigger) {
+				LOGGER.fine("cron checking " + projectName);
+				ParameterizedTimerTrigger ptTrigger = (ParameterizedTimerTrigger) trigger;
+
+				try {
+					ptTrigger.checkCronTabsAndRun(calendar);
+				} catch (Throwable e) {
+					// t.run() is a plugin, and some of them throw RuntimeException and other things.
+					// don't let that cancel the polling activity. report and move on.
+					LOGGER.log(Level.WARNING,
+							trigger.getClass().getName() + ".run() failed for " + projectName, e);
 				}
 			}
 		}

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedStaplerRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedStaplerRequest.java
@@ -511,4 +511,9 @@ public class ParameterizedStaplerRequest implements StaplerRequest {
 	public BindInterceptor setBindInterceptpr(BindInterceptor bindListener) {
 		return null;
 	}
+
+	@Override
+	public BindInterceptor setBindInterceptor(BindInterceptor bindInterceptor) {
+		return null;
+	}
 }

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger.java
@@ -110,9 +110,4 @@ public class ParameterizedTimerTrigger extends Trigger<Job> {
 	public String getParameterizedSpecification() {
 		return parameterizedSpecification;
 	}
-
-	@Override
-	public TriggerDescriptor getDescriptor() {
-		return new DescriptorImpl();
-	}
 }

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger.java
@@ -1,10 +1,6 @@
 package org.jenkinsci.plugins.parameterizedscheduler;
 
-import hudson.model.ParameterValue;
-import hudson.model.AbstractProject;
-import hudson.model.ParameterDefinition;
-import hudson.model.ParametersAction;
-import hudson.model.ParametersDefinitionProperty;
+import hudson.model.*;
 import hudson.scheduler.Hash;
 import hudson.triggers.Trigger;
 
@@ -15,6 +11,9 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.triggers.TriggerDescriptor;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import antlr.ANTLRException;
@@ -26,7 +25,7 @@ import antlr.ANTLRException;
  *
  */
 @SuppressWarnings("rawtypes")
-public class ParameterizedTimerTrigger extends Trigger<AbstractProject> {
+public class ParameterizedTimerTrigger extends Trigger<Job> {
 	private static final Logger LOGGER = Logger.getLogger(ParameterizedTimerTrigger.class.getName());
 	private transient ParameterizedCronTabList cronTabList;
 	private final String parameterizedSpecification;
@@ -72,16 +71,26 @@ public class ParameterizedTimerTrigger extends Trigger<AbstractProject> {
 	public void checkCronTabsAndRun(Calendar calendar) {
 		LOGGER.fine("checking and maybe running at " + calendar);
 		ParameterizedCronTab cronTab = cronTabList.check(calendar);
+		Jenkins jenkins = Jenkins.getInstance();
+
 		if (cronTab != null) {
 			Map<String, String> parameterValues = cronTab.getParameterValues();
 			ParametersAction parametersAction = new ParametersAction(configurePropertyValues(parameterValues));
 			assert job != null : "job must not be null, if this was 'started'";
-			job.scheduleBuild2(0, new ParameterizedTimerTriggerCause(parameterValues), parametersAction);
+			if (job instanceof AbstractProject) {
+				((AbstractProject) job).scheduleBuild2(0, null, causeAction(parameterValues), parametersAction);
+			} else if (jenkins != null && jenkins.getPlugin("workflow-job") != null && job instanceof WorkflowJob) {
+				((WorkflowJob) job).scheduleBuild2(0, causeAction(parameterValues), parametersAction);
+			}
 		}
 	}
 
+	private CauseAction causeAction(Map<String, String> parameterValues) {
+		return new CauseAction(new ParameterizedTimerTriggerCause(parameterValues));
+	}
+
 	@Override
-	public void start(AbstractProject project, boolean newInstance) {
+	public void start(Job project, boolean newInstance) {
 		this.job = project;
 
 		try {// reparse the tabs with the job as the hash
@@ -102,4 +111,8 @@ public class ParameterizedTimerTrigger extends Trigger<AbstractProject> {
 		return parameterizedSpecification;
 	}
 
+	@Override
+	public TriggerDescriptor getDescriptor() {
+		return new DescriptorImpl();
+	}
 }

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTriggerCause.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTriggerCause.java
@@ -4,8 +4,6 @@ import hudson.model.Cause;
 
 import java.util.Map;
 
-import org.jenkinsci.plugins.parameterizedscheduler.Messages;
-
 public class ParameterizedTimerTriggerCause extends Cause {
 
 	private final String description;

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,6 +1,7 @@
 <!--
   This view is used to render the installed plugins page.
 -->
+<?jelly escape-by-default='true'?>
 <div>
   This plugin is for configuring a cron style timer schedule for parameterized builds.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!--
     This jelly script is used for per-project configuration.

--- a/src/main/resources/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!--
     This Jelly script is used to produce the global configuration option.


### PR DESCRIPTION
Based on [peppelan's PR](https://github.com/jenkinsci/parameterized-scheduler-plugin/pull/1), I fixed its bug and updated  version as @batmat requested.

It fix parameter missing bug after refresh page and migrate 1.642.3 without skipping jenkins tests. 
I had tried to migrate 1.580.1 (first version of jenkins pipeline support) but could not due to `java.lang.ClassNotFoundException: jenkins.model.queue.AsynchronousExecution` in Jenkins UnitTest.
It was tested on jenkins v2.19.1 and works well.

Thank you @peppelan to permit skipping merging his original PR. (https://github.com/peppelan/parameterized-scheduler-plugin/pull/1)