### PR TITLE
JENKINS-37139 JENKINS-44031 add support for declarative pipelines as parameterizedCron trigger + updated checkSanity function to operate on multi-line strings, fixes "'%' characters are present" error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin()

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Parameterized Scheduler
 A Jenkins Plugin to support setting parameters in the build schedule. Using multiple cron lines each ending with a % and some name=value pairs you can schedule your parameterized build to run with different parameters at different times. It may turn out that
 [this improvement request JENKINS-16352](https://issues.jenkins-ci.org/browse/JENKINS-16352)
 will be implemented in Jenkins core. Then this plugin will no longer be needed. My first thought is to try it out as a plugin.
+This plugin now supports [declarative Jenkins pipelines](https://jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline). See configuration example below.
 
 ## Installation ##
 Clone or fork to build the .hpi yourself (_mvn package_) or download the .hpi from my release. Then follow the [Jenkins Plugin installation instructions](https://wiki.jenkins-ci.org/display/JENKINS/Plugins#Plugins-Howtoinstallplugins)
@@ -43,4 +44,36 @@ Then you might want a schedule like the following:
   5 * * * *%furniture=chair;color=black
   # now, let's override that default name and use Mr. Rubble.
   10 * * * * % furniture=desk; color=yellow; name=barney
+```
+
+## Declarative Pipeline Configuration Example ##
+
+The parameterized cron trigger can be specified using the key  `parameterizedCron` under the [triggers directive](https://jenkins.io/doc/book/pipeline/syntax/#declarative-directives). The built in `cron` trigger is still available and is independent of `parameterizedCron`.
+
+Example:
+
+```
+pipeline {
+    agent any
+    options {
+      string(name: 'PLANET', defaultValue: 'Earth', description: 'Which planet are we on?')
+      string(name: 'GREETING', defaultValue: 'Hello', description: 'How shall we greet?')
+    }
+    triggers {
+        cron('H 4/* 0 0 1-5')
+        parameterizedCron('''
+        # leave spaces where you want them around the parameters. They'll be trimmed.
+        # we let the build run with the default name
+        5 * * * * %GREETING=Hola;PLANET=Pluto
+        10 * * * * %PLANET=Mars
+        ''')
+    }
+    stages {
+        stage('Example') {
+            steps {
+                echo "${GREETING} ${PLANET}"
+            }
+        }
+    }
+}
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
 			<artifactId>workflow-job</artifactId>
 			<version>2.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci</groupId>
+			<artifactId>symbol-annotation</artifactId>
+			<version>1.5</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/DescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/DescriptorImpl.java
@@ -8,7 +8,7 @@ import hudson.model.Job;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.FormValidation;
-
+import org.jenkinsci.Symbol;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.AncestorInPath;
@@ -16,7 +16,7 @@ import org.kohsuke.stapler.QueryParameter;
 
 import antlr.ANTLRException;
 
-@Extension
+@Extension @Symbol("parameterizedCron")
 public class DescriptorImpl extends TriggerDescriptor {
 
 	/**

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterParser.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterParser.java
@@ -38,24 +38,25 @@ public class ParameterParser {
 	}
 
 	public String checkSanity(String cronTabSpec, ParametersDefinitionProperty parametersDefinitionProperty) {
-		String[] split = cronTabSpec.split(PARAMETER_SEPARATOR);
-		if (split.length < 2) {
-			return null;
-		}
-		if (split.length > 2) {
-			return Messages.ParameterizedTimerTrigger_MoreThanOnePercent();
-		}
-
-		try {
-			Map<String, String> parsedParameters = parse(split[1]);
-			List<String> parameterDefinitionNames = parametersDefinitionProperty.getParameterDefinitionNames();
-			List<String> parsedKeySet = new ArrayList<String>(parsedParameters.keySet());
-			parsedKeySet.removeAll(parameterDefinitionNames);
-			if (!parsedKeySet.isEmpty()) {
-				return Messages.ParameterizedTimerTrigger_UndefinedParameter(parsedKeySet, parameterDefinitionNames);
+		String[] cronTabLines = cronTabSpec.split("\\r?\\n");
+		for (int i = 0; i < cronTabLines.length; i++) {
+			String[] split = cronTabLines[i].split(PARAMETER_SEPARATOR);
+			if (split.length > 2) {
+				return Messages.ParameterizedTimerTrigger_MoreThanOnePercent();
 			}
-		} catch (IllegalArgumentException e) {
-			return e.getMessage();
+			if (split.length == 2) {
+				try {
+					Map<String, String> parsedParameters = parse(split[1]);
+					List<String> parameterDefinitionNames = parametersDefinitionProperty.getParameterDefinitionNames();
+					List<String> parsedKeySet = new ArrayList<String>(parsedParameters.keySet());
+					parsedKeySet.removeAll(parameterDefinitionNames);
+					if (!parsedKeySet.isEmpty()) {
+						return Messages.ParameterizedTimerTrigger_UndefinedParameter(parsedKeySet, parameterDefinitionNames);
+					}
+				} catch (IllegalArgumentException e) {
+					return e.getMessage();
+				}
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
A small fix to support declarative pipelines. Would be nice to get this in a 0.4.1 release. This plugin provides a badly needed feature!