### PR TITLE
set scheduler second to zero

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/Cron.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/Cron.java
@@ -26,6 +26,11 @@ public class Cron extends PeriodicWork {
 	}
 
 	@Override
+	public long getInitialDelay() {
+		return MIN - (Calendar.getInstance().get(Calendar.SECOND) * 1000);
+	}
+
+	@Override
 	protected void doRun() throws Exception {
 		Jenkins instance = Jenkins.getInstance();
 


### PR DESCRIPTION
## Problem

Currently scheduled job `second` is defined randomly, so sometimes job run with delay max 59 seconds.

https://github.com/jenkinsci/jenkins/blob/b057abc7b84295969b894d06011e250842c6d09c/core/src/main/java/hudson/model/PeriodicWork.java#L81-L93

## Changes

Generally `Cron` job second is defined ZERO like following, so parameterized cron job should use this also.

https://github.com/jenkinsci/jenkins/blob/b057abc7b84295969b894d06011e250842c6d09c/core/src/main/java/hudson/triggers/Trigger.java#L218-L220