### PR TITLE
Feature/changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changes for the _Jenkins Parameterized Scheduler Plugin_
 
+## [0.6.3] - 2017-10-14
+### Set scheduler second to zero
+
+## [0.6.2] - 2018-06-21
+
+## [0.6.1] - 2018-06-21
+### Changed
+Remove reflection and code duplication
+
 ## [0.5] - 2017-07-17
 ### Added
 [Declarative pipeline syntax support](https://github.com/jenkinsci/parameterized-scheduler-plugin#declarative-pipeline-configuration-example)
@@ -13,6 +22,14 @@ Pipeline support
 ## [0.4-beta-1] - 2017-03-25
 ### Added
  Pipeline support Beta [JENKINS-37139](https://issues.jenkins-ci.org/browse/JENKINS-37139)
+
+## [0.3.1] - 2017-03-25
+### Changed
+Bump to parent pom 2.x, core 1.642.3, and require JDK7+
+
+## [0.3] - 2017-03-25
+### Changed
+Ignore whitespace after parameter delimeter
 
 ## [0.2] - 2015-10-19
 Not user facing change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,21 @@
-= Changes for the _Jenkins Parameterized Scheduler Plugin_
+# Changes for the _Jenkins Parameterized Scheduler Plugin_
 
-* 0.1 : First release to the world
-* 0.2 : Not user facing change
-* 0.4-beta-1 Pipeline support Beta [JENKINS-37139](https://issues.jenkins-ci.org/browse/JENKINS-37139)
-* 0.4 Pipeline support
-* 0.5 Added [Declarative pipeline syntax support](https://github.com/jenkinsci/parameterized-scheduler-plugin#declarative-pipeline-configuration-example) and [JENKINS-44031](https://issues.jenkins-ci.org/browse/JENKINS-44031) resolved.
+## [0.5] - 2017-07-17
+### Added
+[Declarative pipeline syntax support](https://github.com/jenkinsci/parameterized-scheduler-plugin#declarative-pipeline-configuration-example)
+### Fixed
+[JENKINS-44031](https://issues.jenkins-ci.org/browse/JENKINS-44031) resolved.
+
+## [0.4] - 2017-05-12
+### Added
+Pipeline support
+
+## [0.4-beta-1] - 2017-03-25
+### Added
+ Pipeline support Beta [JENKINS-37139](https://issues.jenkins-ci.org/browse/JENKINS-37139)
+
+## [0.2] - 2015-10-19
+Not user facing change
+
+## [0.1] - 2015-10-18
+First release to the world


### PR DESCRIPTION
Made changelog follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format, and added missing releases. Based the descriptions on commit messages found between the release tags.