### PR TITLE
Fix multiple parameter values

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedStaplerRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedStaplerRequest.java
@@ -215,6 +215,9 @@ public class ParameterizedStaplerRequest implements StaplerRequest {
 
 	@Override
 	public String[] getParameterValues(String name) {
+		if (value != null) {
+			return value.split(",")
+		}
 		return new String[] { value };
 	}
 

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedStaplerRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedStaplerRequest.java
@@ -216,7 +216,7 @@ public class ParameterizedStaplerRequest implements StaplerRequest {
 	@Override
 	public String[] getParameterValues(String name) {
 		if (value != null) {
-			return value.split(",")
+			return value.split(",");
 		}
 		return new String[] { value };
 	}


### PR DESCRIPTION
getParameterValues should split value If parameter has multiple comma delimited values. below pattern fails in case of extended-choice-parameter-plugin
`H * * * * %param1=val1,abc,val3`
Check [createValue](https://github.com/jenkinsci/extended-choice-parameter-plugin/blob/7d1dfdb434cb0605e5d2000cbc6ca238b6a287d2/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java#L545) method in extended-choice-parameter-plugin