### PR TITLE
Fix declarative pipeline example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,21 +60,18 @@ pipeline {
       string(name: 'GREETING', defaultValue: 'Hello', description: 'How shall we greet?')
     }
     triggers {
-        cron('* * * * *')
-        parameterizedCron {
-          parameterizedSpecification('''
-# leave spaces where you want them around the parameters. They'll be trimmed.
-# we let the build run with the default name
-*/2 * * * * %GREETING=Hola;PLANET=Pluto
-*/3 * * * * %PLANET=Mars
+        parameterizedCron('''
+            # leave spaces where you want them around the parameters. They'll be trimmed.
+            # we let the build run with the default name
+            */2 * * * * %GREETING=Hola;PLANET=Pluto
+            */3 * * * * %PLANET=Mars
         ''')
-        }
     }
     stages {
         stage('Example') {
             steps {
-                echo "${GREETING} ${PLANET}"
-                script { currentBuild.description = "${GREETING} ${PLANET}" }
+                echo "${params.GREETING} ${params.PLANET}"
+                script { currentBuild.description = "${params.GREETING} ${params.PLANET}" }
             }
         }
     }


### PR DESCRIPTION
The current example did not work (copy/paste in Jenkins pipeline => error)
This PR proposes a working example.

Details :
Jenkins version : 2.190.1
Parameterized Scheduler : 0.8


Error with current example :
```
Running in Durability level: MAX_SURVIVABILITY
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 9: Triggers definitions cannot have blocks @ line 9, column 9.
           parameterizedCron {
           ^

1 error

	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
	at org.codehaus.groovy.control.CompilationUnit.applyToPrimaryClassNodes(CompilationUnit.java:1085)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:603)
	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:581)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:558)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:142)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:127)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:561)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:522)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:327)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Finished: FAILURE
```