### PR TITLE
Fix - Concurrent jobs launch: start several cron expressions at the same time

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabList.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabList.java
@@ -2,17 +2,16 @@ package org.jenkinsci.plugins.parameterizedscheduler;
 
 import hudson.scheduler.CronTabList;
 import hudson.scheduler.Hash;
-import hudson.scheduler.Messages;
 
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
-
+import java.util.stream.Collectors;
 import antlr.ANTLRException;
 
 /**
  * mostly a copy of {@link CronTabList}
- * 
+ *
  * @author jameswilson
  *
  */
@@ -45,12 +44,10 @@ public class ParameterizedCronTabList {
 		return new ParameterizedCronTabList(result);
 	}
 
-	public ParameterizedCronTab check(Calendar calendar) {
-		for (ParameterizedCronTab tab : cronTabs) {
-			if (tab.check(calendar))
-				return tab;
-		}
-		return null;
+	public List<ParameterizedCronTab> check(Calendar calendar) {
+		return cronTabs.stream()
+				.filter(tab -> tab.check(calendar))
+				.collect(Collectors.toList());
 	}
 
 	public String checkSanity() {

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import hudson.triggers.TriggerDescriptor;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -20,7 +19,7 @@ import antlr.ANTLRException;
 
 /**
  * {@link Trigger} that runs a job periodically with support for parameters.
- * 
+ *
  * @author jameswilson
  *
  */
@@ -43,7 +42,7 @@ public class ParameterizedTimerTrigger extends Trigger<Job> {
 
 	/**
 	 * this method started out as hudson.model.AbstractProject.getDefaultParametersValues()
-	 * @param parameterValues 
+	 * @param parameterValues
 	 * @return the ParameterValues as set from the crontab row or their defaults
 	 */
 	@SuppressWarnings("unchecked")
@@ -70,10 +69,10 @@ public class ParameterizedTimerTrigger extends Trigger<Job> {
 
 	public void checkCronTabsAndRun(Calendar calendar) {
 		LOGGER.fine("checking and maybe running at " + calendar);
-		ParameterizedCronTab cronTab = cronTabList.check(calendar);
+		List<ParameterizedCronTab> checkedCronTabList = cronTabList.check(calendar);
 		Jenkins jenkins = Jenkins.getInstance();
 
-		if (cronTab != null) {
+		checkedCronTabList.forEach(cronTab -> {
 			Map<String, String> parameterValues = cronTab.getParameterValues();
 			ParametersAction parametersAction = new ParametersAction(configurePropertyValues(parameterValues));
 			assert job != null : "job must not be null, if this was 'started'";
@@ -82,7 +81,7 @@ public class ParameterizedTimerTrigger extends Trigger<Job> {
 			} else if (jenkins != null && jenkins.getPlugin("workflow-job") != null && job instanceof WorkflowJob) {
 				((WorkflowJob) job).scheduleBuild2(0, causeAction(parameterValues), parametersAction);
 			}
-		}
+		});
 	}
 
 	private CauseAction causeAction(Map<String, String> parameterValues) {
@@ -104,7 +103,7 @@ public class ParameterizedTimerTrigger extends Trigger<Job> {
 
 	/**
 	 * for the config.jelly to populate
-	 * 
+	 *
 	 * @return the raw specification
 	 */
 	public String getParameterizedSpecification() {


### PR DESCRIPTION
Hi there,

I liked the plugin and idea of setting up multiple cron expressions with different parameters. I looked through readme and found an image where two jobs (#18, #19) were launched at the same time. That was exactly what I needed.

But, unfortunately, I was not able to setup configuration to run different periodical cron expressions at the same time.
Digging into the code, I realized that this plugin worked differently:
- It runs a check every minute to launch a cron task with specific parameters.
- It makes a lookup only for the first cron expression that should start at that moment.

Based on the documentation and real implementation, I concluded that there was a bug in code, or it was the desired behavior and misleading documentation. 