### PR TITLE
[JENKINS-52009] Added support for timezone in cron and percent sign in parameter key/value

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTab.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTab.java
@@ -35,14 +35,19 @@ public class ParameterizedCronTab {
 	 *      Used to spread out token like "@daily". Null to preserve the legacy behaviour
 	 *      of not spreading it out at all.
 	 */
-	public static ParameterizedCronTab create(String line, int lineNumber, Hash hash) throws ANTLRException {
-		String[] lineParts = line.split("%");
-		CronTab cronTab = new CronTab(lineParts[0].trim(), lineNumber, hash);
+	public static ParameterizedCronTab create(String line, int lineNumber, Hash hash, String timezone) throws ANTLRException {
 		Map<String, String> parameters = Maps.newHashMap();
-		if (lineParts.length == 2) {
-			parameters = new ParameterParser().parse(lineParts[1]);
+		int firstPercentIdx = line.indexOf("%");
+		if(firstPercentIdx != -1) {
+			String cronLinePart = line.substring(0, firstPercentIdx).trim();
+			String paramsLinePart = line.substring(firstPercentIdx + 1).trim();
+			CronTab cronTab = new CronTab(cronLinePart, lineNumber, hash, timezone);
+			parameters = new ParameterParser().parse(paramsLinePart);
+			return new ParameterizedCronTab(cronTab, parameters);
+		} else {
+			CronTab cronTab = new CronTab(line, lineNumber, hash, timezone);
+			return new ParameterizedCronTab(cronTab, parameters);
 		}
-		return new ParameterizedCronTab(cronTab, parameters);
 	}
 
 	public Map<String, String> getParameterValues() {

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabList.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabList.java
@@ -31,15 +31,23 @@ public class ParameterizedCronTabList {
 	public static ParameterizedCronTabList create(String cronTabSpecification, Hash hash) throws ANTLRException {
 		List<ParameterizedCronTab> result = new ArrayList<ParameterizedCronTab>();
 		int lineNumber = 0;
+		String timezone = null;
 		for (String line : cronTabSpecification.split("\\r?\\n")) {
-			lineNumber++;
 			line = line.trim();
-			if (line.length() == 0 || line.startsWith("#"))
-				continue; // ignorable line
-			try {
-				result.add(ParameterizedCronTab.create(line, lineNumber, hash));
-			} catch (ANTLRException e) {
-				throw new ANTLRException(String.format("Invalid input: \"%s\": %s", line, e.toString()), e);
+			if(line.length() > 0 && !line.startsWith("#")) {
+				lineNumber++;
+				if(lineNumber == 1 && line.startsWith("TZ=")) {
+					timezone = CronTabList.getValidTimezone(line.replace("TZ=", ""));
+					if (timezone == null) {
+						throw new ANTLRException("Invalid or unsupported timezone '" + line + "'");
+					}
+				} else {
+					try {
+						result.add(ParameterizedCronTab.create(line, lineNumber, hash, timezone));
+					} catch (ANTLRException e) {
+						throw new ANTLRException(String.format("Invalid input: \"%s\": %s", line, e.toString()), e);
+					}
+				}
 			}
 		}
 		return new ParameterizedCronTabList(result);

--- a/src/main/resources/org/jenkinsci/plugins/parameterizedscheduler/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/parameterizedscheduler/Messages.properties
@@ -1,6 +1,6 @@
 ParameterizedTimerTrigger.DisplayName=Build periodically with parameters
 ParameterizedTimerTrigger.MissingWhitespace=You appear to be missing whitespace between * and *.
-ParameterizedTimerTrigger.MoreThanOnePercent=You can only use one percent sign to separate the cron from the parameters.
+ParameterizedTimerTrigger.MoreThanOnePercent=First percent sign is used to separate the cron from the parameters.
 ParameterizedTimerTrigger.TrailingSemicolon=I need you to remove that semicolon from the end of the line.
 ParameterizedTimerTrigger.UndefinedParameter=You have tried to schedule with parameters ({0}), which are not among saved project parameters: {1} 
 ParameterizedTimerTrigger.TimerTriggerCause.ShortDescription=Started by timer with parameters: {0}

--- a/src/main/resources/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger/help-parameterizedSpecification.html
+++ b/src/main/resources/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger/help-parameterizedSpecification.html
@@ -29,5 +29,10 @@
 H/15 * * * * %name=value
 # every ten minutes in the first half of every hour (three times, perhaps at :04, :14, :24)
 H(0-29)/10 * * * * % name=value; othername=othervalue
+# every fifteen minutes with timezone
+TZ=Australia/Sydney
+H/15 * * * * %name=value
+# every fifteen minutes with percent sign in param key/value
+H/15 * * * * %name=value;key=10%;
 </pre>
 </div>

--- a/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterParserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterParserTest.java
@@ -148,4 +148,14 @@ public class ParameterParserTest {
 		testObject.checkSanity("* * * * *%name=value;name2=", mockParametersDefinitionProperty);
 	}
 
+	@Test
+	public void test_paramValue_with_percent() {
+		ParameterParser testObject = new ParameterParser();
+
+		HashMap<String, String> expected = new HashMap<String, String>();
+		expected.put("name", "value");
+		expected.put("percent", "10%");
+		assertEquals(expected, testObject.parse("name=value;percent=10%"));
+	}
+
 }

--- a/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabListTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabListTest.java
@@ -107,4 +107,16 @@ public class ParameterizedCronTabListTest {
 
 	}
 
+	@Test
+	public void create_with_timezone() throws Exception {
+		ParameterizedCronTabList testObject = ParameterizedCronTabList.create("TZ=Australia/Sydney \n * * * * *%foo=bar");
+		assertTrue(testObject.checkSanity(), testObject.checkSanity().startsWith("Do you really mean \"every minute\""));
+		ParameterizedCronTab actualCronTab = testObject.check(new GregorianCalendar());
+		assertTrue(actualCronTab != null);
+
+		Map<String, String> expected = Maps.newHashMap();
+		expected.put("foo", "bar");
+		assertEquals(expected, actualCronTab.getParameterValues());
+	}
+
 }

--- a/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabTest.java
@@ -8,6 +8,7 @@ import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.Map;
 
+import hudson.scheduler.Hash;
 import org.jenkinsci.plugins.parameterizedscheduler.ParameterizedCronTab;
 import org.junit.Test;
 import org.jvnet.localizer.LocaleProvider;
@@ -39,6 +40,32 @@ public class ParameterizedCronTabTest {
 		assertTrue(testObject.check(new GregorianCalendar()));
 		assertTrue(testObject.checkSanity().startsWith("Do you really mean"));
 
+	}
+
+	@Test
+	public void param_value_with_percent_sign() throws Exception {
+		String cron = "* * * * *";
+		String params = "one=onevalue;two=10%";
+		String line = cron +" %" + params;
+		Map<String, String> parameters = Maps.newHashMap();
+		parameters.put("one", "onevalue");
+		parameters.put("two", "10%");
+		CronTab testCronTab = new CronTab("* * * * *");
+		ParameterizedCronTab testObject = new ParameterizedCronTab(testCronTab, parameters);
+
+		ParameterizedCronTab parameterizedCronTab = ParameterizedCronTab.create(line, 1, Hash.from(line), null);
+		assertEquals(parameters, parameterizedCronTab.getParameterValues());
+
+	}
+
+	@Test
+	public void with_no_params_seperator() throws Exception {
+		String line = "* * * * *";
+		Map<String, String> parameters = Maps.newHashMap();
+		CronTab testCronTab = new CronTab("* * * * *");
+		ParameterizedCronTab testObject = new ParameterizedCronTab(testCronTab, parameters);
+		ParameterizedCronTab parameterizedCronTab = ParameterizedCronTab.create(line, 1, Hash.from(line), null);
+		assertEquals(parameters, parameterizedCronTab.getParameterValues());
 	}
 
 }


### PR DESCRIPTION
**Current behavior** : No way to set timezone for all the parameterized cron expressions.
**After this change** : Timezone in first line will be applied to all the cron expressions see below for example.
TZ=Australia/Sydney
H/15 * * * * %name=value
H(0-29)/10 * * * * % name=value; othername=othervalue

The timezone Australia/Sydney will be applied for both the crons.

**Current behavior** : If percent sign is part of some parameter key or value then all the parameters of the job are ignored.
**After this change** : Only the first % sign will be used to separate the cron expression from the parameters. Any other percent sign in key/value will be part of the key/value see below for example

H/15 * * * * %name=value;key=10%;
The parameters will be name=value, key=10%
