### PR TITLE
Remove misleading reference to `parameterizedSpecification`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then you might want a schedule like the following:
 
 ## Declarative Pipeline Configuration Example
 
-The parameterized cron trigger can be specified using the key `parameterizedSpecification` under the `parameterizedCron` under the [triggers directive](https://jenkins.io/doc/book/pipeline/syntax/#declarative-directives). The built in `cron` trigger is still available and is independent of `parameterizedCron`.
+The parameterized cron trigger can be specified using the key `parameterizedCron` under the [triggers directive](https://jenkins.io/doc/book/pipeline/syntax/#declarative-directives). The built in `cron` trigger is still available and is independent of `parameterizedCron`.
 
 Example:
 


### PR DESCRIPTION
I'm not quite sure if I miss something but in the pipeline examples there is no `parameterizedSpecification`.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
