### PR TITLE
Use Jenkins >= 2.289.3, update BOM and POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.41</version>
+		<version>4.43.1</version>
 	</parent>
 
 	<artifactId>parameterized-scheduler</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.24</version>
+		<version>4.41</version>
 	</parent>
 
 	<artifactId>parameterized-scheduler</artifactId>
@@ -16,8 +16,7 @@
 		<revision>1.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/parameterized-scheduler-plugin</gitHubRepo>
-		<java.level>8</java.level>
-		<jenkins.version>2.222.4</jenkins.version>
+		<jenkins.version>2.289.3</jenkins.version>
 	</properties>
 
 	<name>Parameterized Scheduler</name>
@@ -97,8 +96,8 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.222.x</artifactId>
-				<version>887.vae9c8ac09ff7</version>
+				<artifactId>bom-2.289.x</artifactId>
+				<version>1451.v15f1fdb_772a_f</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>


### PR DESCRIPTION
Requires Jenkins > 2.289.3 and update BOM and POM to their latest version. `.3` is needed by *git-server*.

`java.level` is [deprecated since POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) and should be removed.

This PR enables building on newer Java Version.

---------------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
