### PR TITLE
Enable ParameterizedCronTabListTest on non-english environments

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabListTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabListTest.java
@@ -12,9 +12,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import antlr.ANTLRException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -23,10 +26,21 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParameterizedCronTabListTest {
+	private static final Locale defaultLocale = Locale.getDefault();
 	@Mock
 	private ParameterizedCronTab mockParameterizedCronTab;
 	@Mock
 	private ParameterizedCronTab mockParameterizedCronTabToo;
+
+	@BeforeClass
+	public static void initLocale() {
+		Locale.setDefault(Locale.ENGLISH);
+	}
+
+	@AfterClass
+	public static void resetLocale() {
+		Locale.setDefault(defaultLocale);
+	}
 
 	@Test
 	public void create() throws Exception {


### PR DESCRIPTION
Some tests of this suite fail on environments with non-english locales. Assertions expect english strings, but on these systems the message is translated.

If Before / After Class isn't suitable, I can implement a Rule instead.

-------------------------------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
