### PR TITLE
Double-% typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The idea was born from the need to use a different environment. To use a differe
 # lets run against the integration environment at 15 past the hour
 15 * * * * %env=int
 # run QA too
-30 * * * * %%env=qa
+30 * * * * %env=qa
 ```
 
 Yes, of course you can set multiple parameters. Lets say you have three parameters:


### PR DESCRIPTION
Assuming this was not intended.
I spent a few seconds wondering if that was a feature but it does not seem to be referenced anywhere, so…
(And the project this is forked from has a similar-looking example with only a single `%`.)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue