### PR TITLE
build-user-vars compatibility

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTriggerCause.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTriggerCause.java
@@ -1,10 +1,11 @@
 package org.jenkinsci.plugins.parameterizedscheduler;
 
-import hudson.model.Cause;
+import hudson.triggers.TimerTrigger;
 
 import java.util.Map;
+import java.util.Objects;
 
-public class ParameterizedTimerTriggerCause extends Cause {
+public class ParameterizedTimerTriggerCause extends TimerTrigger.TimerTriggerCause {
 
 	private final String description;
 
@@ -18,4 +19,17 @@ public class ParameterizedTimerTriggerCause extends Cause {
 		return description;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+		ParameterizedTimerTriggerCause that = (ParameterizedTimerTriggerCause) o;
+		return Objects.equals(description, that.description);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), description);
+	}
 }

--- a/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTriggerCauseTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTriggerCauseTest.java
@@ -1,10 +1,14 @@
 package org.jenkinsci.plugins.parameterizedscheduler;
 
+import hudson.triggers.TimerTrigger;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 
 public class ParameterizedTimerTriggerCauseTest {
@@ -19,4 +23,9 @@ public class ParameterizedTimerTriggerCauseTest {
 				testObject.getShortDescription());
 	}
 
+	@Test
+	public void isTimerTrigger() {
+		assertThat(new ParameterizedTimerTriggerCause(Collections.singletonMap("a", "b")),
+				instanceOf(TimerTrigger.TimerTriggerCause.class));
+	}
 }


### PR DESCRIPTION
Adds build-user-vars compatibility. 

Extends `TimerTrigger.TimerTriggerCause` instead of `Cause` so build-user-vars sets it's variables [as the normal `cron` trigger](https://github.com/jenkinsci/build-user-vars-plugin/blob/master/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/TimerTriggerCauseDeterminant.java).

Jobs triggered with parameters to get only `null`s otherwise.

/cc @fabiodcasilva



----------------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
