### PR TITLE
Use SCM HTTPS URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
 	</developers>
 
 	<scm>
-		<connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+		<developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
 		<url>https://github.com/${gitHubRepo}</url>
 		<tag>${scmTag}</tag>
 	</scm>


### PR DESCRIPTION
The old protocols are [deprecated](https://github.blog/2021-09-01-improving-git-protocol-security-github/).