### PR TITLE
[JENKINS-69691] Fix permission check

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/DescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/DescriptorImpl.java
@@ -8,7 +8,6 @@ import hudson.model.Item;
 import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.model.ParametersDefinitionProperty;
-import hudson.security.Permission;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.FormValidation;
 import org.jenkinsci.Symbol;
@@ -54,7 +53,7 @@ public class DescriptorImpl extends TriggerDescriptor {
 	@POST
 	public FormValidation doCheckParameterizedSpecification(@QueryParameter String value,
 			@AncestorInPath Job<?, ?> job) {
-		job.checkPermission(Permission.CONFIGURE);
+		job.checkPermission(Item.CONFIGURE);
 		try {
 
 			String msg = ParameterizedCronTabList.create(fixNull(value)).checkSanity();


### PR DESCRIPTION
[JENKINS-69691](https://issues.jenkins.io/browse/JENKINS-69691) The permission check should use `Item.CONFIGURE` instead of the generic `Permission.CONFIGURE`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
