### PR TITLE
Fix Cron periodic work to run at the beginning of each minute.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/Cron.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/Cron.java
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.parameterizedscheduler;
 
 import hudson.Extension;
 import hudson.model.AbstractProject;
-import hudson.model.PeriodicWork;
+import hudson.model.AperiodicWork;
 import hudson.triggers.Trigger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -10,17 +10,24 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.GregorianCalendar;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @Extension
-public class Cron extends PeriodicWork {
+public class Cron extends AperiodicWork {
 	private static final Logger LOGGER = Logger.getLogger(Cron.class.getName());
+
+	// time constants
+	protected static final long MIN = 1000 * 60;
+
+	@Override
+	public AperiodicWork getNewInstance() {
+		return new Cron();
+	}
 
 	@Override
 	public long getRecurrencePeriod() {
-		return TimeUnit.MINUTES.toMillis(1);
+		return getInitialDelay();
 	}
 
 	@Override
@@ -29,7 +36,7 @@ public class Cron extends PeriodicWork {
 	}
 
 	@Override
-	protected void doRun() {
+	protected void doAperiodicRun() {
 		Jenkins instance = Jenkins.get();
 
 		for (AbstractProject<?, ?> project : instance.allItems(AbstractProject.class)) {


### PR DESCRIPTION
In previous implementation, initially invocation time is aligned to the of the first minute, but eventually 1-minute period can flow because of local clock inaccuracy. This commit fixes this by dynamic calculation of delay before execution.

Details:
PeriodicWork uses java.util.concurrent.ScheduledThreadPoolExecutor.scheduleAtFixedRate, which uses java.lang.System.nanoTime() to determine time elapsed. It does not strictly correlate with wall-clock time. In case we faced with, Cron periodic work became running at 59 second of each minute (our machine's clock is late) and sometimes some jobs became skip triggering

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
