### PR TITLE
Remove usages of deprecated `ANTLRException`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<changelist>999999-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-		<jenkins.version>2.375.1</jenkins.version>
+		<jenkins.version>2.426.3</jenkins.version>
 	</properties>
 
 	<name>Parameterized Scheduler</name>
@@ -90,8 +90,8 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.375.x</artifactId>
-				<version>2198.v39c76fc308ca</version>
+				<artifactId>bom-2.426.x</artifactId>
+				<version>2839.v003b_4d9d24fd</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/DescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/DescriptorImpl.java
@@ -15,7 +15,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 
-import antlr.ANTLRException;
 import org.kohsuke.stapler.verb.POST;
 
 @Extension @Symbol("parameterizedCron")
@@ -68,11 +67,9 @@ public class DescriptorImpl extends TriggerDescriptor {
 			}
 
 			return FormValidation.ok();
-		} catch (ANTLRException e) {
+		} catch (IllegalArgumentException e) {
 			if (value.trim().indexOf('\n') == -1 && value.contains("**"))
 				return FormValidation.error(Messages.ParameterizedTimerTrigger_MissingWhitespace());
-			return FormValidation.error(e.getMessage());
-		} catch (IllegalArgumentException e) {
 			return FormValidation.error(e.getMessage());
 		}
 	}

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTab.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTab.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import antlr.ANTLRException;
 import hudson.scheduler.CronTab;
 import hudson.scheduler.CronTabList;
 import hudson.scheduler.Hash;
@@ -34,7 +33,7 @@ public class ParameterizedCronTab {
 	 *      Used to spread out token like "@daily". Null to preserve the legacy behaviour
 	 *      of not spreading it out at all.
 	 */
-	public static ParameterizedCronTab create(String line, int lineNumber, Hash hash, String timezone) throws ANTLRException {
+	public static ParameterizedCronTab create(String line, int lineNumber, Hash hash, String timezone) {
 		Map<String, String> parameters = new HashMap<>();
 		int firstPercentIdx = line.indexOf("%");
 		if(firstPercentIdx != -1) {

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabList.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabList.java
@@ -8,8 +8,6 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import antlr.ANTLRException;
-
 /**
  * mostly a copy of {@link CronTabList}
  * 
@@ -24,11 +22,11 @@ public class ParameterizedCronTabList {
 		this.cronTabs = cronTabs;
 	}
 
-	public static ParameterizedCronTabList create(String cronTabSpecification) throws ANTLRException {
+	public static ParameterizedCronTabList create(String cronTabSpecification) {
 		return create(cronTabSpecification, null);
 	}
 
-	public static ParameterizedCronTabList create(String cronTabSpecification, Hash hash) throws ANTLRException {
+	public static ParameterizedCronTabList create(String cronTabSpecification, Hash hash) {
 		List<ParameterizedCronTab> result = new ArrayList<>();
 		int lineNumber = 0;
 		String timezone = null;
@@ -39,13 +37,13 @@ public class ParameterizedCronTabList {
 				if(lineNumber == 1 && line.startsWith("TZ=")) {
 					timezone = CronTabList.getValidTimezone(line.replace("TZ=", ""));
 					if (timezone == null) {
-						throw new ANTLRException("Invalid or unsupported timezone '" + line + "'");
+						throw new IllegalArgumentException("Invalid or unsupported timezone '" + line + "'");
 					}
 				} else {
 					try {
 						result.add(ParameterizedCronTab.create(line, lineNumber, hash, timezone));
-					} catch (ANTLRException e) {
-						throw new ANTLRException(String.format("Invalid input: \"%s\": %s", line, e), e);
+					} catch (IllegalArgumentException e) {
+						throw new IllegalArgumentException(String.format("Invalid input: \"%s\": %s", line, e), e);
 					}
 				}
 			}

--- a/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedTimerTrigger.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.parameterizedscheduler;
 
-import antlr.ANTLRException;
 import hudson.model.AbstractProject;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
@@ -34,7 +33,7 @@ public class ParameterizedTimerTrigger extends Trigger<Job> {
 	private final String parameterizedSpecification;
 
 	@DataBoundConstructor
-	public ParameterizedTimerTrigger(String parameterizedSpecification) throws ANTLRException {
+	public ParameterizedTimerTrigger(String parameterizedSpecification) {
 		this.parameterizedSpecification = parameterizedSpecification;
 		this.cronTabList = ParameterizedCronTabList.create(parameterizedSpecification);
 	}
@@ -102,7 +101,7 @@ public class ParameterizedTimerTrigger extends Trigger<Job> {
 
 		try {// reparse the tabs with the job as the hash
 			cronTabList = ParameterizedCronTabList.create(parameterizedSpecification, Hash.from(project.getFullName()));
-		} catch (ANTLRException e) {
+		} catch (IllegalArgumentException e) {
 			// this shouldn't fail because we've already parsed stuff in the constructor,
 			// so if it fails, use whatever 'tabs' that we already have.
 			LOGGER.log(Level.FINE, "Failed to parse crontab spec: " + spec, e);

--- a/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabListTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parameterizedscheduler/ParameterizedCronTabListTest.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import antlr.ANTLRException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -145,8 +144,8 @@ public class ParameterizedCronTabListTest {
 		assertEquals(expected, actualCronTabs.get(0).getParameterValues());
 	}
 
-	@Test(expected = ANTLRException.class)
-	public void create_with_invalidTimezone() throws ANTLRException {
+	@Test(expected = IllegalArgumentException.class)
+	public void create_with_invalidTimezone() {
 		ParameterizedCronTabList.create("TZ=Dune/Arrakis \n * * * * *%foo=bar");
 	}
 


### PR DESCRIPTION
In recent versions of core, catching `IllegalArgumentException` is preferred to minimize API exposure of ANTLR.