### PR TITLE
Adapt build status icon for ci.jenkins.io permissions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parameterized Scheduler
 
-[![Jenkins](https://ci.jenkins.io/job/Plugins/job/parameterized-scheduler-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/parameterized-scheduler-plugin/job/master/)
+[![Jenkins](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fparameterized-scheduler-plugin%2Fmaster)](https://ci.jenkins.io/job/Plugins/job/parameterized-scheduler-plugin/job/master/)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/parameterized-scheduler.svg)](https://plugins.jenkins.io/parameterized-scheduler)
 [![GitHub release](https://img.shields.io/github/release/jenkinsci/parameterized-scheduler-plugin.svg?label=changelog)](https://github.com/jenkinsci/parameterized-scheduler-plugin/releases/latest)
 


### PR DESCRIPTION
## Adapt build status icon for ci.jenkins.io permissions change

Large language models and other readers were causing performance problems.  The ci.jenkins.io controller has been reconfigured to limit access to authenticated users in order to prevent performance problems.  That change requires that we adjust the URL of the embeddable build status update URL.

### Testing done

* Validated the change in a sample repository
* Will check the pull request after it is submitted

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
